### PR TITLE
Mark Darkbar as EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Darkbar
+
+___This application is no longer maintained.___

--- a/com.github.bluesabre.darkbar.yml
+++ b/com.github.bluesabre.darkbar.yml
@@ -40,3 +40,8 @@ modules:
         url: https://github.com/bluesabre/darkbar.git
         tag: 1.0.1
         commit: "b1d2ac4d232848b125fe5a6f62e917a1c67542bf"
+    post-install:
+      # workaround for non-png-icon-in-hicolor-size-folder lint error
+      - mkdir -p /app/share/icons/hicolor/scalable/apps
+      - mv /app/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+      - find /app/share/icons/hicolor -type f -not -path "*scalable*" -not -path "*actions*" -name "*.svg" -delete

--- a/com.github.bluesabre.darkbar.yml
+++ b/com.github.bluesabre.darkbar.yml
@@ -6,8 +6,6 @@ command: com.github.bluesabre.darkbar
 finish-args:
 # Reading .desktop and icon files needed to display application details
   - '--filesystem=host:ro'
-  - '--filesystem=xdg-data/flatpak/app:ro'
-  - '--filesystem=/var/lib/flatpak/app:ro'
 # Creating an autostart file to launch in the background at startup
   - '--filesystem=xdg-config/autostart:create'
 # Standard Permissions

--- a/com.github.bluesabre.darkbar.yml
+++ b/com.github.bluesabre.darkbar.yml
@@ -6,8 +6,6 @@ command: com.github.bluesabre.darkbar
 finish-args:
 # Reading .desktop and icon files needed to display application details
   - '--filesystem=host:ro'
-# Creating an autostart file to launch in the background at startup
-  - '--filesystem=xdg-config/autostart:create'
 # Standard Permissions
   - '--share=ipc'
 # X11 is enforced to take advantage of libwnck for Xwayland windows

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "end-of-life": "This application is no longer maintained."
+}


### PR DESCRIPTION
This application uses an old runtime that was marked as end-of-life (EOL) two years ago.

Apart from translations, there has been no real development activity for years, and the project appears to be stalled.
https://github.com/bluesabre/darkbar/commits/main/

The application is heavily reliant on X11, and Wayland server is not supported.

It doesn't work in modern distributions.

Hence, I suggest marking this application as end-of-life (EOL).

```
$ LC_ALL=C flatpak remote-info flathub --system org.gnome.Platform//42
End-of-life: The GNOME 42 runtime is no longer supported as of March 21, 2023. 
Date: 2023-03-22 12:44:22 +0000
```
